### PR TITLE
fix: Change log level from warning to error in inner logger methods mixin

### DIFF
--- a/lib/src/inner_logger_methods_mixin.dart
+++ b/lib/src/inner_logger_methods_mixin.dart
@@ -43,7 +43,7 @@ base mixin InnerLoggerMethodsMixin on InnerLogger {
       super.log(
         LogMessage.create(
           message,
-          const LogLevel.warning(),
+          const LogLevel.error(),
           stackTrace: stackTrace,
           context: context,
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Cross-platform html/io Logger library with simple API.
   Manipulate with native and web console.
   Support ascii colorize output.
-version: 5.0.0-pre.2
+version: 5.0.0-pre.3
 repository: https://github.com/PlugFox/l/tree/master
 issue_tracker: https://github.com/PlugFox/l/issues
 homepage: https://github.com/PlugFox/l


### PR DESCRIPTION
fix: Change log level from warning to error in inner logger methods mixin